### PR TITLE
fix: integration step filter type field name

### DIFF
--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -57,9 +57,10 @@ pub struct Credentials {
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct StepFilter {
+    #[serde(rename = "isNegated")]
     is_negated: bool,
+    #[serde(rename = "type")]
     step_filter_type: StepFilterType,
     value: StepFilterValue,
     children: Vec<FieldFilterPart>,


### PR DESCRIPTION
- type can't be used as is a keyword use serde rename

Signed-off-by: Lakshya Singh <lakshay.singh1108@gmail.com>
